### PR TITLE
fix: trim newline

### DIFF
--- a/src/components/csv-upload/index.jsx
+++ b/src/components/csv-upload/index.jsx
@@ -21,6 +21,7 @@ export default function CSVUpload() {
         header: true, // first row is headers
         skipEmptyLines: true,
         dynamicTyping: true, // Automatically convert types like dates, numbers, etc.
+        transform: (value) => value.replace(/\n/g, ""), // Remove \n characters
         complete: (results) => {
           const rows = results.data;
           const headerKeys = Object.keys(rows[0] || {}); // Get headers from the first row of data


### PR DESCRIPTION
Trim `\n` from the end of parsed values, seen here:
![image](https://github.com/user-attachments/assets/07a66401-a21d-4a95-b4c6-07171607cc06)

I could not replicate this issue, but `transform: (value) => value.replace(/\n/g, "")` was added to `Papa.parse` in hopes of fixing it, if it is happening